### PR TITLE
Decode base64 sample holder key in test code

### DIFF
--- a/sdjwt.js
+++ b/sdjwt.js
@@ -146,7 +146,7 @@ async function issue(holder, frame = []) {
 
 (async () => {
   return;  
-  const holder = "eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImhfTGI2bGkzc05CU281RjB1TDNZa1BUemtZby1peEpGZmdqWWp4Z2thbk0iLCJ5IjoiNzZpZ3dsMkp3WkdBc3dMbVpwMjZ4a3B2Ulk4YmhxemhoVW9tUEhDMWdsVSJ9";
+  const holder = `{"crv":"P-256","kty":"EC","x":"h_Lb6li3sNBSo5F0uL3YkPTzkYo-ixJFfgjYjxgkanM","y":"76igwl2JwZGAswLmZp26xkpvRY8bhqzhhUomPHC1glU"}`;
 
   const sdjwt = await issue(holder, [
     ["sub", "https://sgo.to"],


### PR DESCRIPTION
It seems that the holder key is raw JSON and not base64-encoded.
This PR fixes the issue by using the base64-decoded holder key.


The path to code decoding holder key as JSON directly:
- https://github.com/samuelgoto/static-issuer/blob/59a2ff055f4bfde47e021487e6f5d0aa39c5acbb/sdjwt.js#L149
- https://github.com/samuelgoto/static-issuer/blob/59a2ff055f4bfde47e021487e6f5d0aa39c5acbb/sdjwt.js#L151
- https://github.com/samuelgoto/static-issuer/blob/59a2ff055f4bfde47e021487e6f5d0aa39c5acbb/sdjwt.js#L125